### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,6 +19,7 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,65 +4,68 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
+      <%# 商品が売れていればsold outの表示 %>
+      <% if @item.order != nil %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
+      <% end %>
+      <%# //商品が売れていればsold outの表示 %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>円
       </span>
       <span class="item-postage">
         (税込) 送料込み
       </span>
     </div>
-
-    <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう%>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-    <%# // ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう %>
-
+    <%# 商品が売れている場合、商品の編集・削除・購入を表示しない %>
+    <% if @item.order != nil %>
+    <%# // 商品が売れている場合、商品の編集・削除・購入を表示しない %>
+    <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示%>
+    <% elsif user_signed_in? && @item.user.id == current_user.id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <%# // ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示 %>
+    <%# ログインユーザと出品したユーザが異なる時、商品の購入を表示 %>
+    <% else %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end %>
+    <%# // ログインユーザと出品したユーザが異なる時、商品の購入を表示 %>
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.info %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= Category.find(@item.category_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= SalesStatus.find(@item.sales_status_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= ShippingFeeStatus.find(@item.shipping_fee_status_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= Prefecture.find(@item.prefecture_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= ScheduledDelivery.find(@item.scheduled_delivery_id).name %></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
# What
商品詳細ページを作成

#Why
- 商品の詳細を確認できるようにするため
- 売れていない商品の場合、出品者は商品の編集・削除ページへのリンクを表示するため、出品者以外は商品の購入ページへのリンクを表示するため
---
- ログアウト状態でも商品詳細ページを閲覧できる（購入リンクを踏んだあとの動作は、商品購入機能にて実装します）
https://gyazo.com/68e8db7bd56df9e394cc841837a846d5
- 出品者には、商品編集・削除のリンクが表示される
https://gyazo.com/a722ba0d070522576d9b8cc050952fe2
- 出品者以外には、商品購入のリンクが表示される
https://gyazo.com/50cec9d8fbaa4c7740533b6c8127a816